### PR TITLE
chore: fix Dockerfiles to use pnpm, deploy on develop push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - release
+      - develop
 
 env:
   NODE_VERSION: 20

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,112 @@
+# Aadhya Web
+
+Frontend for the Aadhya platform — a React single-page application for assessments, activities, and multiple intelligences analysis. Supports multiple languages (English, Spanish, French, Hindi).
+
+## Tech Stack
+
+| Category | Technology |
+|----------|------------|
+| Runtime | Node.js 18+ |
+| Language | TypeScript 5.9 (strict mode) |
+| Package Manager | pnpm |
+| Framework | React 18 |
+| Build Tool | Vite 5 |
+| Routing | React Router 7 |
+| Server State | TanStack React Query 5 |
+| Forms | React Hook Form + Zod |
+| UI Components | Radix UI / Shadcn + Lucide icons |
+| Styling | Tailwind CSS 4 + PostCSS |
+| Charts | Recharts |
+| i18n | i18next (en, es, fr, hi) |
+| HTTP Client | Axios |
+| Date Utils | dayjs |
+| Testing | Vitest + React Testing Library |
+| Code Quality | ESLint + Prettier |
+| Containerization | Docker + Docker Compose + Nginx |
+
+## Key Commands
+
+```bash
+pnpm install                  # Install dependencies
+pnpm dev                      # Dev server (port 3000, hot reload)
+pnpm build                    # TypeScript check + Vite production build
+pnpm preview                  # Preview production build locally
+pnpm test                     # Run tests with Vitest
+pnpm test:watch               # Watch mode testing
+pnpm test:coverage            # Coverage report
+pnpm test:ui                  # Vitest UI dashboard
+pnpm type-check               # TypeScript check without emitting
+pnpm lint:fix                 # Fix ESLint issues
+pnpm format:fix               # Fix Prettier formatting
+docker compose up              # Dev environment
+docker compose --profile prod up  # Production (Nginx)
+```
+
+## Project Structure
+
+```
+src/
+  main.tsx                     # Entry point — renders React root
+  App.tsx                      # Root component (QueryClient + Router)
+  router/AppRouter.tsx         # Route definitions with protected routes
+  pages/                       # Page components (Home, Login, Assessment, etc.)
+  components/
+    ui/                        # Shadcn UI primitives (button, card, radio-group)
+    blocks/                    # Composite block components
+    forms/                     # Form components (LoginForm, ContactForm)
+    charts/                    # Chart components
+    activity-components/       # Activity-specific components
+    Layout.tsx                 # App layout wrapper
+    Navigation.tsx             # Navigation menu
+    ProtectedRoute.tsx         # Auth route guard
+    LanguageSwitcher.tsx       # Language selection
+  services/
+    apiConfig.ts               # API base URL and fetch utilities
+    authService.ts             # Login/logout/token management
+    activitiesApi.ts           # Activities endpoints
+    assessmentsApi.ts          # Assessments endpoints
+  hooks/                       # Custom hooks (useActivities, useAssessments, useZodForm)
+  lib/                         # Utilities (axios config, date utils, MI scoring, mappings)
+  schemas/                     # Zod validation schemas
+  types/                       # TypeScript type definitions
+  data/                        # Static data (questions, MI questions JSON)
+  i18n/locales/                # Translation files (en, es, fr, hi)
+
+Dockerfile                     # Production multi-stage (Node build → Nginx)
+Dockerfile.dev                 # Development image (hot reload)
+docker-compose.yml             # Dev + prod profiles
+nginx.conf                     # Production Nginx config (SPA fallback, caching, security headers)
+```
+
+## Routes
+
+| Path | Description | Auth |
+|------|-------------|------|
+| `/login` | Login page | Public |
+| `/` `/home` | Main landing page | Protected |
+| `/assessment/:id/start` | Assessment overview | Protected |
+| `/assessment/:id/activity/:activityId` | Activity/assessment page | Protected |
+| `/assessment/:id/thank-you` | Completion page | Protected |
+| `/pehachan` | Pehchan module | Protected |
+| `/sajag` | Sajag module | Protected |
+
+## Environment Variables
+
+See `.env.example`. Key ones:
+
+```
+VITE_API_BASE_URL=http://localhost:3001/api   # Backend API URL
+VITE_APP_NAME=Aadhya Web
+VITE_ENVIRONMENT=development
+```
+
+Default API base: `http://localhost:3001/api/v1`
+
+## Docker
+
+Docker is already configured for both dev and production:
+
+- **Dev:** `Dockerfile.dev` — Node 18, hot reload on port 3000
+- **Prod:** `Dockerfile` — Multi-stage build (Node 18 compile → Nginx alpine), serves static assets on port 80
+- **Nginx:** SPA routing fallback, security headers, 1-year static asset caching
+- **Compose profiles:** default (dev), `dev`, `prod`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,22 @@
 # Build stage
-FROM node:18-alpine as build
+FROM node:20-alpine AS build
 
 WORKDIR /app
 
-# Copy package files
-COPY package*.json ./
+RUN corepack enable && corepack prepare pnpm@10.15.1 --activate
 
-# Install dependencies
-RUN npm ci --only=production
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
 
-# Copy source code
 COPY . .
-
-# Build the app
-RUN npm run build
+RUN pnpm build
 
 # Production stage
-FROM nginx:alpine
+FROM nginx:1.27-alpine
 
-# Copy built assets from build stage
 COPY --from=build /app/dist /usr/share/nginx/html
-
-# Copy nginx configuration
 COPY nginx.conf /etc/nginx/nginx.conf
 
-# Expose port
 EXPOSE 80
 
-# Start nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,19 +1,15 @@
 # Development Dockerfile
-FROM node:18-alpine
+FROM node:20-alpine
 
 WORKDIR /app
 
-# Copy package files
-COPY package*.json ./
+RUN corepack enable && corepack prepare pnpm@10.15.1 --activate
 
-# Install dependencies
-RUN npm install
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install
 
-# Copy source code
 COPY . .
 
-# Expose port
 EXPOSE 3000
 
-# Start development server
-CMD ["npm", "run", "dev"]
+CMD ["pnpm", "dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # Development service
   aadhya-web-dev:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aadhya-web",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- **Dockerfile & Dockerfile.dev**: switch from `npm` to `pnpm` (no `package-lock.json` exists, only `pnpm-lock.yaml`), upgrade Node 18 → 20
- **CI/CD**: add `develop` branch to deploy trigger so pushes/merges to develop auto-deploy
- Remove deprecated `version: '3.8'` from docker-compose.yml
- Add CLAUDE.md project summary

## Test plan
- [ ] Merge to develop triggers the deploy workflow
- [ ] Docker build succeeds with pnpm
- [ ] Site loads at urf.buildstack.space

🤖 Generated with [Claude Code](https://claude.com/claude-code)